### PR TITLE
Addressing issues 12 and 17

### DIFF
--- a/datebulb/urls.py
+++ b/datebulb/urls.py
@@ -1,15 +1,18 @@
 from django.urls import include, path
 from rest_framework import routers
-from user_manager import views as user_views
+from user_manager.views import *
 from idea_manager import views as idea_views
 
 router = routers.DefaultRouter()
-router.register(r'users', user_views.UserViewSet)
+router.register(r'users', UserViewSet)
 router.register(r'dateideas', idea_views.DateIdeaViewSet)
 
 # Wire up our API using automatic URL routing.
 # Additionally, we include login URLs for the browsable API.
 urlpatterns = [
     path('', include(router.urls)),
-    path('api-auth/', include('rest_framework.urls', namespace='rest_framework'))
+    path('api-auth/', include('rest_framework.urls', namespace='rest_framework')),
+    path('set-csrf/', set_csrf_token, name='Set-CSRF'),
+    path('login/', login_view, name='Login'),
+    path('test-auth/', CheckAuth.as_view(), name='check-auth')
 ]

--- a/user_manager/serializers.py
+++ b/user_manager/serializers.py
@@ -2,8 +2,23 @@ from django.contrib.auth.models import User
 from rest_framework import serializers
 
 
-class UserSerializer(serializers.HyperlinkedModelSerializer):
+class UserSerializer(serializers.ModelSerializer):
+
+    # take plain text as input, but store passwords as hashes
+    def create(self, validated_data):
+        if "password" in validated_data:
+            from django.contrib.auth.hashers import make_password
+            validated_data["password"] = make_password(
+                validated_data["password"])
+        return super().create(validated_data)
+
+    def update(self, instance, validated_data):
+        if "password" in validated_data:
+            from django.contrib.auth.hashers import make_password
+            validated_data["password"] = make_password(
+                validated_data["password"])
+        return super().update(instance, validated_data)
+
     class Meta:
         model = User
-        fields = ['url', 'username', 'email', 'password']
-
+        fields = '__all__'

--- a/user_manager/views.py
+++ b/user_manager/views.py
@@ -1,13 +1,68 @@
+from rest_framework.response import Response
+from rest_framework.authentication import SessionAuthentication
+from rest_framework.views import APIView
+from django.http import JsonResponse
+from django.views.decorators.csrf import ensure_csrf_cookie
+from django.views.decorators.http import require_POST
+from django.contrib.auth import authenticate, login
+import json
 from django.contrib.auth.models import User
-from rest_framework import viewsets
-from rest_framework import permissions
+from rest_framework import mixins, viewsets
 from user_manager.serializers import UserSerializer
 
 
-class UserViewSet(viewsets.ModelViewSet):
-    """
-    API endpoint that allows users to be viewed or edited.
-    """
+"""
+SIGN UP / USER CREATION
+"""
+
+
+class UserViewSet(mixins.CreateModelMixin, viewsets.GenericViewSet):
     queryset = User.objects.all().order_by('-date_joined')
     serializer_class = UserSerializer
-    permission_classes = [permissions.IsAuthenticated]
+
+
+"""
+AUTHENTICATION: CREDIT TO - https://github.com/kieronjmckenna/DRF-React-Auth/blob/master/auth-react/src/App.js
+"""
+
+
+@ensure_csrf_cookie
+def set_csrf_token(request):
+    return JsonResponse({"details": "CSRF cookie set"})
+
+
+@require_POST
+def login_view(request):
+    data = json.loads(request.body)
+    username = data.get('username')
+    password = data.get('password')
+
+    if username is None or password is None:
+        return JsonResponse({
+            "errors": {
+                "__all__": "Please enter both username and password"
+            }
+        }, status=400)
+
+    user = authenticate(username=username, password=password)
+
+    if user is not None:
+        login(request, user)
+        return JsonResponse({"detail": "Success"})
+
+    return JsonResponse(
+        {"detail": "Invalid credentials"},
+        status=400,
+    )
+
+
+"""
+TESTING
+"""
+
+
+class CheckAuth(APIView):
+    authentication_classes = [SessionAuthentication]
+
+    def get(self, request):
+        return Response({'detail': 'You\'re Authenticated'})


### PR DESCRIPTION
Made the Following Changes:

1. Changed the User serializer to accept clear text passwords as input but store passwords as hashes
2. Changed the user model viewset to a generic viewset with create mixin - Now useful as a signup view that does not allow users to view others data
3. Added a Login view as well as token authentication: credit to @kieronjmckenna 
https://github.com/kieronjmckenna/DRF-React-Auth/